### PR TITLE
fix: make safe-rm module robust in CI

### DIFF
--- a/dotfiles-linux/safe-rm/main
+++ b/dotfiles-linux/safe-rm/main
@@ -2,6 +2,11 @@
 
 set -eo pipefail
 
+# ensure lg exists for non-interactive shells
+if ! command -v lg &>/dev/null; then
+  lg() { echo "$@"; }
+fi
+
 # check if safe-rm is installed
 if ! command -v safe-rm &>/dev/null; then
     lg "safe-rm could not be found (skipping)"


### PR DESCRIPTION
CI failure was due to the safe-rm module calling `lg` in a non-interactive shell. This adds a fallback `lg` definition so the module can skip safely when safe-rm isn’t installed.